### PR TITLE
Disable autocorrect for user input

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -60,7 +60,7 @@
       </span>)
       </span>
       
-      <input type="text" id="userInput" autocomplete="off" autocapitalize="off" spellcheck="false" />
+      <input type="text" id="userInput" autocomplete="off" autocapitalize="off" spellcheck="false" autocorrect="off" />
       
       <div style="min-height:50px">
          <div id="wrong" style="display:none;">


### PR DESCRIPTION
In addition to the attributes added in #5, the attribute `autocorrect="off"` is also necessary to actually disable virtual keyboard autocorrections.

This is currently a non-standard attribute that's supported in Chrome and Safari. Hopefully it will be supported by Firefox in the future.